### PR TITLE
PR: Fixed wslutils & winget error

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Currently supported distros:
 - Debian
 - Alpine
 - OpenSUSE
-- Any other linux distribution with `apt-get` or `zypper` as paket manager
+- Any other linux distribution with `apt-get` or `zypper` as packet manager
 
 ## Alternatives
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository includes the files to set-up WSL2 distro to run systemd.
 - Configure xdg-open to open files and addresses in Windows
 
 #### In Windows
-- Install GPG4Win via winget.exe, which is available in the latest dev branch of Windows 10 Insider Preview.
+- Install GPG4Win via winget.exe, which is available in the latest dev branch of Windows 10 Insider Preview. (disable this with `-NoGPG`)
 - Add a scheduled task that launches when you login to Windows to start the GPG-Agent from GPG4Win
 - Install a custom WSL kernel based on the Microsoft sources with AppArmor added to support [Snap Package](https://snapcraft.io) strict confinement.
 - Add a scheduled task that launches when you login to Windows to update the custom kernel when a new release is made.
@@ -27,12 +27,22 @@ This repository includes the files to set-up WSL2 distro to run systemd.
     ```powershell
     powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -File \path\to\install.ps1
     ```
+If you want to skip the GPG4Win installation, use the flag `-NoGPG`
 
-You can also specify a distro name with the `-distro Ubuntu-20.04` flag:
+You can also specify a distro name with the `-distro` flag, e.g:
 
 ```powershell
 powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -File \path\to\install.ps1 -distro Ubuntu-20.04
 ```
+You will find all the available distros on your system when executing `wsl.exe --list --all` in command prompt
+
+Currently supported distros:
+- Ubuntu
+- Kali Linux
+- Debian
+- Alpine
+- OpenSUSE
+- Any other linux distribution with `apt-get` or `zypper` as paket manager
 
 ## Alternatives
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-param($Distro, $User)
+param($Distro, $User, [switch]$NoGPG)
 
 $repoUrl = 'https://github.com/diddlesnaps/one-script-wsl2-systemd/raw/master/'
 
@@ -226,7 +226,7 @@ do_sles() {
     SLESCUR_VERSION="$(grep VERSION= /etc/os-release | sed -e s/VERSION=//g -e s/\"//g -e s/-/_/g)"
     sudo zypper addrepo https://download.opensuse.org/repositories/home:/wslutilities/SLE_$SLESCUR_VERSION/home:wslutilities.repo
     sudo zypper addrepo https://download.opensuse.org/repositories/graphics/SLE_12_SP3_Backports/graphics.repo
-    zypper --non-interactive install wslu
+    zypper --non-interactive --no-gpg-checks install wslu
 }
 do_zypper() {
     zypper addrepo https://download.opensuse.org/repositories/home:/wslutilities/openSUSE_Leap_15.1/home:wslutilities.repo
@@ -262,8 +262,12 @@ fi
 '@
 
 # Install GPG4Win
-Write-Output '--- Installing GPG4Win in Windows'
-winget.exe install --silent gnupg.Gpg4win
+if ($NoGPG) {
+    Write-Output 'Skipping Gpg4win installation'
+} else {
+    Write-Output '--- Installing GPG4Win in Windows'
+    winget.exe install --silent gnupg.Gpg4win
+}
 
 Write-Output '--- Adding a Windows scheduled tasks and starting services'
 


### PR DESCRIPTION
Hi there,

thank you so much for that awesome script. Had two issues which I fixed with this pull request:

1. Installation of wslutils failed because of a fingerprint mismatch. If you run zypper in `--non-interactive` mode, the standard behaviour is to cancel the installtion. I fixed this with `--no-gpg-checks`, since it's a third party repo anyway.
2. winget.exe only works if you have Windows Insider Preview or App-Installer installed. A TODO would be to check if that command is available or not. Currently it throws an exception if you do not have winget.exe installed. To fix this temporarely you can now use the flag `-NoGPG` and it will skip the installation of GPG4Win.
3. Edited the README.md

--
kylhuk

P.S.: This is my first ever pull request, so please let me know if I have to do change something. Thanks!